### PR TITLE
Update links to new documentation location 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Dyalog/Voc
 ## References
-1. [Language Elements](https://help.dyalog.com/latest/Content/Language/Introduction/Language%20Elements.htm)
+1. [Glyphs](https://docs.dyalog.com/20.0/language-reference-guide/glyphs/)
 2. [Dyalog APL · Primitives](https://aplwiki.com/wiki/Dyalog_APL#Primitives)

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" type="image/png" href="logo.png" />
     <title>Dyalog APL - Vocabulary</title>
+    <base href="https://dyalog.github.io/documentation/latest/"></base>
   </head>
   <body>
     <main>
@@ -37,56 +38,56 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Add.htm"
+                  href="language-reference-guide/primitive-functions/add"
                   >Plus</a
                 >
               </td>
               <td class="function">+</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Conjugate.htm"
+                  href="language-reference-guide/primitive-functions/conjugate"
                   >Conjugate</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Symbols/Minus%20Sign.htm"
+                  href="language-reference-guide/symbols/minus-sign"
                   >Minus</a
                 >
               </td>
               <td class="function">-</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Negative.htm"
+                  href="language-reference-guide/primitive-functions/negative"
                   >Negate</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Multiply.htm"
+                  href="language-reference-guide/primitive-functions/multiply"
                   >Times</a
                 >
               </td>
               <td class="function">×</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Direction.htm"
+                  href="language-reference-guide/primitive-functions/direction"
                   >Direction</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Divide.htm"
+                  href="language-reference-guide/primitive-functions/divide"
                   >Divide</a
                 >
               </td>
               <td class="function">÷</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Reciprocal.htm"
+                  href="language-reference-guide/primitive-functions/reciprocal"
                   >Reciprocal</a
                 >
               </td>
@@ -95,56 +96,56 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Maximum.htm"
+                  href="language-reference-guide/primitive-functions/maximum"
                   >Maximum</a
                 >
               </td>
               <td class="function">⌈</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Ceiling.htm"
+                  href="language-reference-guide/primitive-functions/ceiling"
                   >Ceiling</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Minimum.htm"
+                  href="language-reference-guide/primitive-functions/minimum"
                   >Minimum</a
                 >
               </td>
               <td class="function">⌊</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Floor.htm"
+                  href="language-reference-guide/primitive-functions/floor"
                   >Floor</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Power.htm"
+                  href="language-reference-guide/primitive-functions/power"
                   >Power</a
                 >
               </td>
               <td class="function">*</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Exponential.htm"
+                  href="language-reference-guide/primitive-functions/exponential"
                   >Exponential</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Logarithm.htm"
+                  href="language-reference-guide/primitive-functions/logarithm"
                   >Logarithm</a
                 >
               </td>
               <td class="function">⍟</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Natural%20Logarithm.htm"
+                  href="language-reference-guide/primitive-functions/natural-logarithm"
                   >Natural<br/>
                   Logarithm</a
                 >
@@ -154,7 +155,7 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Circular.htm"
+                  href="language-reference-guide/primitive-functions/circular"
                 >
                   Circular</a
                 >
@@ -162,49 +163,49 @@
               <td class="function">○</td>
               <td>
                 <a
-                  href=" https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Pi%20Times.htm"
+                  href="language-reference-guide/ primitive-functions/pi-times"
                   >Pi Times</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Binomial.htm"
+                  href="language-reference-guide/primitive-functions/binomial"
                   >Binomial</a
                 >
               </td>
               <td class="function">!</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Factorial.htm"
+                  href="language-reference-guide/primitive-functions/factorial"
                   >Factorial</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Deal.htm"
+                  href="language-reference-guide/primitive-functions/deal"
                   >Deal</a
                 >
               </td>
               <td class="function">?</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Roll.htm"
+                  href="language-reference-guide/primitive-functions/roll"
                   >Roll</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Residue.htm"
+                  href="language-reference-guide/primitive-functions/residue"
                   >Residue</a
                 >
               </td>
               <td class="function">|</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Magnitude.htm"
+                  href="language-reference-guide/primitive-functions/magnitude"
                   >Magnitude</a
                 >
               </td>
@@ -213,7 +214,7 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/And%20Lowest%20Common%20Multiple.htm"
+                  href="language-reference-guide/primitive-functions/and-lowest-common-multiple"
                   >And/LCM</a
                 >
               </td>
@@ -222,7 +223,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Or%20Greatest%20Common%20Divisor.htm"
+                  href="language-reference-guide/primitive-functions/or-greatest-common-divisor"
                   >Or/GCD</a
                 >
               </td>
@@ -231,7 +232,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Nand.htm"
+                  href="language-reference-guide/primitive-functions/nand"
                   >Nand</a
                 >
               </td>
@@ -240,7 +241,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Nor.htm"
+                  href="language-reference-guide/primitive-functions/nor"
                   >Nor</a
                 >
               </td>
@@ -256,7 +257,7 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Equal.htm"
+                  href="language-reference-guide/primitive-functions/equal"
                   >Equal</a
                 >
               </td>
@@ -265,14 +266,14 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Not%20Equal.htm"
+                  href="language-reference-guide/primitive-functions/not-equal"
                   >Not Equal</a
                 >
               </td>
               <td class="function">≠</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Unique%20Mask.htm"
+                  href="language-reference-guide/primitive-functions/unique-mask"
                   >Unique <br />
                   Mask</a
                 >
@@ -280,28 +281,28 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Match.htm"
+                  href="language-reference-guide/primitive-functions/match"
                   >Match</a
                 >
               </td>
               <td class="function">≡</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Depth.htm"
+                  href="language-reference-guide/primitive-functions/depth"
                   >Depth</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Not%20Match.htm"
+                  href="language-reference-guide/primitive-functions/not-match"
                   >Not Match</a
                 >
               </td>
               <td class="function" style="font-family:APL385 Unicode,APL333,monospace">≢</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Tally.htm"
+                  href="language-reference-guide/primitive-functions/tally"
                   >Tally</a
                 >
               </td>
@@ -310,7 +311,7 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Less.htm"
+                  href="language-reference-guide/primitive-functions/less"
                   >Less </a
                 >
               </td>
@@ -319,7 +320,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Less%20Or%20Equal.htm"
+                  href="language-reference-guide/primitive-functions/less-or-equal"
                   >Less Or <br />
                   Equal</a
                 >
@@ -329,7 +330,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Symbols/Greater%20Than%20Or%20Equal%20To%20Sign.htm"
+                  href="language-reference-guide/symbols/greater-than-or-equal-to-sign"
                 >
                   Greater Or <br />
                   Equal</a
@@ -340,7 +341,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Greater.htm"
+                  href="language-reference-guide/primitive-functions/greater"
                   >Greater </a
                 >
               </td>
@@ -351,56 +352,56 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Index%20with%20Axes.htm"
+                  href="language-reference-guide/primitive-functions/index-with-axes"
                   >Index</a
                 >
               </td>
               <td class="function">⌷</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Materialise.htm"
+                  href="language-reference-guide/primitive-functions/materialise"
                   >Materialise</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Take.htm"
+                  href="language-reference-guide/primitive-functions/take"
                   >Take</a
                 >
               </td>
               <td class="function">↑</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Mix.htm"
+                  href="language-reference-guide/primitive-functions/mix"
                   >Mix</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Drop.htm"
+                  href="language-reference-guide/primitive-functions/drop"
                   >Drop</a
                 >
               </td>
               <td class="function">↓</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Split.htm"
+                  href="language-reference-guide/primitive-functions/split"
                   >Split</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Reshape.htm"
+                  href="language-reference-guide/primitive-functions/reshape"
                   >Reshape</a
                 >
               </td>
               <td class="function">⍴</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Shape.htm"
+                  href="language-reference-guide/primitive-functions/shape"
                   >Shape</a
                 >
               </td>
@@ -409,7 +410,7 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Partitioned%20Enclose.htm"
+                  href="language-reference-guide/primitive-functions/partitioned-enclose"
                 >
                   Partitioned <br />
                   Enclose
@@ -418,49 +419,49 @@
               <td class="function">⊂</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Enclose.htm"
+                  href="language-reference-guide/primitive-functions/enclose"
                   >Enclose</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Pick.htm"
+                  href="language-reference-guide/primitive-functions/pick"
                   >Pick</a
                 >
               </td>
               <td class="function">⊃</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Disclose.htm"
+                  href="language-reference-guide/primitive-functions/disclose"
                   >First</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Left.htm"
+                  href="language-reference-guide/primitive-functions/left"
                   >Left</a
                 >
               </td>
               <td class="function">⊣</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Same.htm"
+                  href="language-reference-guide/primitive-functions/same"
                   >Same</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Right.htm"
+                  href="language-reference-guide/primitive-functions/right"
                   >Right</a
                 >
               </td>
               <td class="function">⊢</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Same.htm"
+                  href="language-reference-guide/primitive-functions/same"
                   >Same</a
                 >
               </td>
@@ -474,35 +475,35 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Partition.htm"
+                  href="language-reference-guide/primitive-functions/partition"
                   >Partition</a
                 >
               </td>
               <td class="function">⊆</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Nest.htm"
+                  href="language-reference-guide/primitive-functions/nest"
                   >Nest</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Union.htm"
+                  href="language-reference-guide/primitive-functions/union"
                   >Union</a
                 >
               </td>
               <td class="function">∪</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Unique.htm"
+                  href="language-reference-guide/primitive-functions/unique"
                   >Unique</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Intersection.htm"
+                  href="language-reference-guide/primitive-functions/intersection"
                   >Intersection</a
                 >
               </td>
@@ -511,14 +512,14 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Excluding.htm"
+                  href="language-reference-guide/primitive-functions/excluding"
                   >Without</a
                 >
               </td>
               <td class="function">~</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Not.htm"
+                  href="language-reference-guide/primitive-functions/not"
                   >Not</a
                 >
               </td>
@@ -527,14 +528,14 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Index%20Of.htm"
+                  href="language-reference-guide/primitive-functions/index-of"
                   >Index Of</a
                 >
               </td>
               <td class="function">⍳</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Index%20Generator.htm"
+                  href="language-reference-guide/primitive-functions/index-generator"
                   >Index<br/>
                   Generator
                 </a
@@ -543,7 +544,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Interval%20Index.htm"
+                  href="language-reference-guide/primitive-functions/interval-index"
                 >
                   Interval <br />
                   Index
@@ -552,28 +553,28 @@
               <td class="function">⍸</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Where.htm"
+                  href="language-reference-guide/primitive-functions/where"
                   >Where</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Membership.htm"
+                  href="language-reference-guide/primitive-functions/membership"
                   >Membership</a
                 >
               </td>
               <td class="function">∊</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Enlist.htm"
+                  href="language-reference-guide/primitive-functions/enlist"
                   >Enlist</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Find.htm"
+                  href="language-reference-guide/primitive-functions/find"
                   >Find</a
                 >
               </td>
@@ -584,7 +585,7 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Replicate.htm"
+                  href="language-reference-guide/primitive-functions/replicate"
                   >Replicate</a
                 >
               </td>
@@ -593,7 +594,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Expand.htm"
+                  href="language-reference-guide/primitive-functions/expand"
                   >Expand</a
                 >
               </td>
@@ -602,7 +603,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Replicate.htm"
+                  href="language-reference-guide/primitive-functions/replicate"
                 >
                   Replicate <br />
                   First
@@ -613,7 +614,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Expand.htm"
+                  href="language-reference-guide/primitive-functions/expand"
                 >
                   Expand <br />
                   First</a
@@ -626,21 +627,21 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Rotate.htm"
+                  href="language-reference-guide/primitive-functions/rotate"
                   >Rotate</a
                 >
               </td>
               <td class="function">⌽</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Reverse.htm"
+                  href="language-reference-guide/primitive-functions/reverse"
                   >Reverse</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Rotate%20First.htm"
+                  href="language-reference-guide/primitive-functions/rotate-first"
                 >
                   Rotate <br />
                   First</a
@@ -649,7 +650,7 @@
               <td class="function">⊖</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Reverse%20First.htm"
+                  href="language-reference-guide/primitive-functions/reverse-first"
                 >
                   Reverse <br />
                   First</a
@@ -658,21 +659,21 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Catenate%20Laminate.htm"
+                  href="language-reference-guide/primitive-functions/catenate-laminate"
                   >Catenate</a
                 >
               </td>
               <td class="function">,</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Ravel.htm"
+                  href="language-reference-guide/primitive-functions/ravel"
                   >Ravel</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Catenate%20First.htm"
+                  href="language-reference-guide/primitive-functions/catenate-first"
                 >
                   Catenate <br />
                   First</a
@@ -681,7 +682,7 @@
               <td class="function">⍪</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Table.htm"
+                  href="language-reference-guide/primitive-functions/table"
                   >Table</a
                 >
               </td>
@@ -695,7 +696,7 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Transpose%20Dyadic.htm"
+                  href="language-reference-guide/primitive-functions/transpose-dyadic"
                 >
                   Reorder <br />
                   Axes</a
@@ -704,14 +705,14 @@
               <td class="function">⍉</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Transpose%20Monadic.htm"
+                  href="language-reference-guide/primitive-functions/transpose-monadic"
                   >Transpose</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Decode.htm"
+                  href="language-reference-guide/primitive-functions/decode"
                   >Decode</a
                 >
               </td>
@@ -720,7 +721,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Encode.htm"
+                  href="language-reference-guide/primitive-functions/encode"
                   >Encode</a
                 >
               </td>
@@ -729,7 +730,7 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Matrix%20Divide.htm"
+                  href="language-reference-guide/primitive-functions/matrix-divide"
                 >
                   Matrix <br />
                   Divide</a
@@ -738,7 +739,7 @@
               <td class="function">⌹</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Matrix%20Inverse.htm"
+                  href="language-reference-guide/primitive-functions/matrix-inverse"
                 >
                   Matrix <br />
                   Inverse</a
@@ -749,7 +750,7 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Execute.htm"
+                  href="language-reference-guide/primitive-functions/execute"
                 >
                   Namespace <br />
                   Execute</a
@@ -758,14 +759,14 @@
               <td class="function">⍎</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Execute.htm"
+                  href="language-reference-guide/primitive-functions/execute"
                   >Execute</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Format%20Dyadic.htm"
+                  href="language-reference-guide/primitive-functions/format-dyadic"
                 >
                   Specified <br />
                   Format</a
@@ -774,14 +775,14 @@
               <td class="function">⍕</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Format%20Monadic.htm"
+                  href="language-reference-guide/primitive-functions/format-monadic"
                   >Format</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Grade%20Up%20Dyadic.htm"
+                  href="language-reference-guide/primitive-functions/grade-up-dyadic"
                 >
                   Collated <br />
                   Grade Up</a
@@ -790,14 +791,14 @@
               <td class="function">⍋</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Grade%20Up%20Monadic.htm"
+                  href="language-reference-guide/primitive-functions/grade-up-monadic"
                   >Grade Up</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Grade%20Down%20Dyadic.htm"
+                  href="language-reference-guide/primitive-functions/grade-down-dyadic"
                 >
                   Collated <br />
                   Grade Down</a
@@ -806,7 +807,7 @@
               <td class="function">⍒</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Grade%20Down%20Monadic.htm"
+                  href="language-reference-guide/primitive-functions/grade-down-monadic"
                   >Grade Down</a
                 >
               </td>
@@ -820,49 +821,49 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Each%20with%20Dyadic%20Operand.htm"
+                  href="language-reference-guide/primitive-operators/each-with-dyadic-operand"
                   >Each</a
                 >
               </td>
               <td class="moperator">f¨</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Each%20with%20Monadic%20Operand.htm"
+                  href="language-reference-guide/primitive-operators/each-with-monadic-operand"
                   >Each</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Constant.htm"
+                  href="language-reference-guide/primitive-operators/constant"
                   >Constant</a
                 >
               </td>
               <td class="moperator">X⍨</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Constant.htm"
+                  href="language-reference-guide/primitive-operators/constant"
                   >Constant</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Commute.htm"
+                  href="language-reference-guide/primitive-operators/commute"
                   >Swap</a
                 >
               </td>
               <td class="moperator">f⍨</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Commute.htm"
+                  href="language-reference-guide/primitive-operators/commute"
                   >Self</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/I%20Beam.htm"
+                  href="language-reference-guide/primitive-operators/i-beam"
                   >System<br/>
                   Service
                 </a
@@ -871,7 +872,7 @@
               <td class="moperator">X⌶</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/I%20Beam.htm"
+                  href="language-reference-guide/primitive-operators/i-beam"
                   >System<br/>
                   Service</a
                 >
@@ -881,7 +882,7 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Reduce%20N%20Wise.htm"
+                  href="language-reference-guide/primitive-operators/reduce-n-wise"
                 >
                   Reduce<br />
                   N-Wise </a
@@ -890,14 +891,14 @@
               <td class="moperator">f/</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Reduce.htm"
+                  href="language-reference-guide/primitive-operators/reduce"
                   >Reduce</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Reduce%20First%20N%20Wise.htm"
+                  href="language-reference-guide/primitive-operators/reduce-first-n-wise"
                 >
                   Reduce First<br />
                   N-Wise </a
@@ -906,7 +907,7 @@
               <td class="moperator">f⌿</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Reduce%20First.htm"
+                  href="language-reference-guide/primitive-operators/reduce-first"
                 >
                   Reduce <br />
                   First</a
@@ -917,7 +918,7 @@
               <td class="moperator">f\</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Scan.htm"
+                  href="language-reference-guide/primitive-operators/scan"
                   >Scan</a
                 >
               </td>
@@ -926,7 +927,7 @@
               <td class="moperator">f⍀</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Scan%20First.htm"
+                  href="language-reference-guide/primitive-operators/scan-first"
                 >
                   Scan <br />
                   First</a
@@ -937,14 +938,14 @@
             <tr>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Key.htm"
+                  href="language-reference-guide/primitive-operators/key"
                   >Key</a
                 >
               </td>
               <td class="moperator">f⌸</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Key.htm"
+                  href="language-reference-guide/primitive-operators/key"
                 >
                   Key <br />
                   Indices</a
@@ -953,35 +954,35 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Spawn.htm"
+                  href="language-reference-guide/primitive-operators/spawn"
                   >Spawn</a
                 >
               </td>
               <td class="moperator">f&</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Spawn.htm"
+                  href="language-reference-guide/primitive-operators/spawn"
                   >Spawn</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/#Language/Primitive%20Operators/Axis%20with%20Dyadic%20Operand.htm"
+                  href="language-reference-guide/https://help.dyalog.com/latest/#language/primitive-operators/axis-with-dyadic-operand"
                   >Axis</a
                 >
               </td>
               <td class="moperator">f[X]</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/#Language/Primitive%20Operators/Axis%20with%20Monadic%20Operand.htm"
+                  href="language-reference-guide/https://help.dyalog.com/latest/#language/primitive-operators/axis-with-monadic-operand"
                   >Axis</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/#Language/Primitive%20Operators/Outer%20Product.htm"
+                  href="language-reference-guide/https://help.dyalog.com/latest/#language/primitive-operators/outer-product"
                 >
                   Outer <br />
                   Product</a
@@ -1003,14 +1004,14 @@
              <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Behind.htm"
+                  href="language-reference-guide/primitive-operators/behind"
                   >Behind</a
                 >
               </td>
               <td class="doperator">f⍛g</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Behind.htm"
+                  href="language-reference-guide/primitive-operators/behind"
                   >Behind</a
                 >
               </td>
@@ -1021,14 +1022,14 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Variant.htm"
+                  href="language-reference-guide/primitive-operators/variant"
                   >Variant</a
                 >
               </td>
               <td class="doperator">f⍠Y</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Variant.htm"
+                  href="language-reference-guide/primitive-operators/variant"
                   >Variant</a
                 >
               </td>
@@ -1040,14 +1041,14 @@
              <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Over.htm"
+                  href="language-reference-guide/primitive-operators/over"
                   >Over</a
                 >
               </td>
               <td class="doperator">f⍥g</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Over.htm"
+                  href="language-reference-guide/primitive-operators/over"
                   >Over</a
                 >
               </td>
@@ -1058,14 +1059,14 @@
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Stencil.htm"
+                  href="language-reference-guide/primitive-operators/stencil"
                   >Stencil</a
                 >
               </td>
               <td class="doperator">f⌺Y</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Stencil.htm"
+                  href="language-reference-guide/primitive-operators/stencil"
                   >Stencil</a
                 >
               </td>
@@ -1075,21 +1076,21 @@
               <td class="doperator">X∘g</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Bind.htm"
+                  href="language-reference-guide/primitive-operators/bind"
                   >Bind</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Beside.htm"
+                  href="language-reference-guide/primitive-operators/beside"
                   >Beside</a
                 >
               </td>
               <td class="doperator">f∘g</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Beside.htm"
+                  href="language-reference-guide/primitive-operators/beside"
                   >Beside</a
                 >
               </td>
@@ -1098,14 +1099,14 @@
               <td class="doperator">f∘Y</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Bind.htm"
+                  href="language-reference-guide/primitive-operators/bind"
                   >Bind</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/At.htm"
+                  href="language-reference-guide/primitive-operators/at"
                   >Bound<br/>
                   At</a
                 >
@@ -1113,7 +1114,7 @@
               <td class="doperator">@</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/At.htm"
+                  href="language-reference-guide/primitive-operators/at"
                   >At</a
                 >
               </td>
@@ -1126,35 +1127,35 @@
              <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Atop.htm"
+                  href="language-reference-guide/primitive-operators/atop"
                   >Atop</a
                 >
               </td>
               <td class="doperator">f⍤g</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Atop.htm"
+                  href="language-reference-guide/primitive-operators/atop"
                   >Atop</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Rank.htm"
+                  href="language-reference-guide/primitive-operators/rank"
                   >Rank</a
                 >
               </td>
               <td class="doperator">f⍤Y</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Rank.htm"
+                  href="language-reference-guide/primitive-operators/rank"
                   >Rank</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Inner%20Product.htm"
+                  href="language-reference-guide/primitive-operators/inner-product"
                 >
                   Inner <br />
                   Product</a
@@ -1169,7 +1170,7 @@
               <td></td>
              <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Power%20Operator.htm"
+                  href="language-reference-guide/primitive-operators/power-operator"
                   >Bound<br/>
                   Until</a
                 >
@@ -1177,14 +1178,14 @@
               <td class="doperator">f⍣g</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Power%20Operator.htm"
+                  href="language-reference-guide/primitive-operators/power-operator"
                   >Until</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Power%20Operator.htm"
+                  href="language-reference-guide/primitive-operators/power-operator"
                   >Bound<br/>
                   Repeat</a
                 >
@@ -1192,7 +1193,7 @@
               <td class="doperator">f⍣Y</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Operators/Power%20Operator.htm"
+                  href="language-reference-guide/primitive-operators/power-operator"
                   >Repeat</a
                 >
              <tr
@@ -1205,7 +1206,7 @@
               <td class="control">→</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Abort.htm"
+                  href="language-reference-guide/primitive-functions/abort"
                   >Abort</a
                 >
               </td>
@@ -1214,7 +1215,7 @@
               <td class="control">⋄</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/TradFns/Statements.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/statements"
                 >
                   Statement <br />
                   Separator</a
@@ -1225,7 +1226,7 @@
               <td class="control">:</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Guards.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/guards"
                   >Guard</a
                 >
               </td>
@@ -1234,7 +1235,7 @@
               <td class="control">::</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Error%20Guards.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/error-guards"
                 >
                   Error <br />
                   Guard</a
@@ -1246,7 +1247,7 @@
               <td class="function">{…}</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Dynamic%20Functions%20and%20Operators.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/dynamic-functions-and-operators"
                   >Dfn</a
                 >
               </td>
@@ -1255,7 +1256,7 @@
               <td class="moperator">{⍺⍺}</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Dynamic%20Operators.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/dynamic-operators"
                 >
                   Monadic <br />
                   Dop</a
@@ -1266,7 +1267,7 @@
               <td class="doperator">{⍵⍵}</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Dynamic%20Operators.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/dynamic-operators"
                 >
                   Dyadic <br />
                   Dop</a
@@ -1277,7 +1278,7 @@
               <td class="noun">⍬</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Primitive%20Functions/Zilde.htm"
+                  href="language-reference-guide/primitive-functions/zilde"
                 >
                   Empty <br />
                   Numeric Vector</a
@@ -1289,7 +1290,7 @@
               <td class="copula">⍺</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Dynamic%20Functions%20and%20Operators.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/dynamic-functions-and-operators"
                 >
                   Left <br />
                   Argument</a
@@ -1300,7 +1301,7 @@
               <td class="function">∇</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Recursion.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/recursion"
                 >
                   Function <br />
                   Self</a
@@ -1311,7 +1312,7 @@
               <td class="noun">⍵</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Dynamic%20Functions%20and%20Operators.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/dynamic-functions-and-operators"
                 >
                   Right <br />
                   Argument</a
@@ -1322,7 +1323,7 @@
               <td class="noun">#</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Introduction/Namespaces/Namespaces.htm"
+                  href="programming-reference-guide/introduction/namespaces/namespaces"
                   >Root</a
                 >
               </td>
@@ -1332,7 +1333,7 @@
               <td class="copula">⍺⍺</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Dynamic%20Operators.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/dynamic-operators"
                 >
                   Left <br />
                   Operand</a
@@ -1343,7 +1344,7 @@
               <td class="copula">∇∇</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Recursion.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/recursion"
                 >
                   Operator <br />
                   Self</a
@@ -1354,7 +1355,7 @@
               <td class="copula">⍵⍵</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/DynamicFunctions/Dynamic%20Operators.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/dfns-and-dops/dynamic-operators"
                 >
                   Right <br />
                   Operand</a
@@ -1365,7 +1366,7 @@
               <td class="noun">##</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Introduction/Namespaces/Namespaces.htm"
+                  href="programming-reference-guide/introduction/namespaces/namespaces"
                   >Parent</a
                 >
               </td>
@@ -1375,7 +1376,7 @@
               <td class="copula">←</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Symbols/Left%20Arrow.htm"
+                  href="language-reference-guide/symbols/left-arrow"
                   >Assign</a
                 >
               </td>
@@ -1384,7 +1385,7 @@
               <td class="copula">⍝</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Defined%20Functions%20and%20Operators/TradFns/Statements.htm"
+                  href="programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/statements"
                   >Comment</a
                 >
               </td>
@@ -1393,7 +1394,7 @@
               <td class="copula">⎕</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/System%20Functions/Evaluated%20Input%20Output.htm"
+                  href="language-reference-guide/system-functions/evaluated-input-output"
                   >Evaluated <br />Input/Stdout</a
                 >
               </td>
@@ -1402,7 +1403,7 @@
               <td class="noun">⍞</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/System%20Functions/Character%20Input%20Output.htm"
+                  href="language-reference-guide/system-functions/character-input-output"
                 >
                   Text <br />
                   Input/Stderr</a
@@ -1414,7 +1415,7 @@
               <td class="function" style="font-size: 0.75em;white-space: nowrap;">(f g h)</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Introduction/Trains.htm"
+                  href="programming-reference-guide/introduction/trains"
                   >Fork</a
                 >
               </td>
@@ -1423,7 +1424,7 @@
               <td class="function" style="font-size: 0.75em;white-space: nowrap;">(X g h)</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Introduction/Trains.htm"
+                  href="language-reference-guide/introduction/trains"
                   >Fork</a
                 >
               </td>
@@ -1432,7 +1433,7 @@
               <td class="function" style="font-size: 0.75em;white-space: nowrap;">(g h)</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Introduction/Trains.htm"
+                  href="programming-reference-guide/introduction/trains"
                   >Atop</a
                 >
               </td>
@@ -1441,7 +1442,7 @@
               <td class="noun">¯</td>
               <td>
                 <a
-                  href="https://help.dyalog.com/latest/Content/Language/Introduction/Variables/Numbers.htm"
+                  href="programming-reference-guide/introduction/arrays/numbers"
                   >Negative</a
                 >
               </td>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" type="image/png" href="logo.png" />
     <title>Dyalog APL - Vocabulary</title>
-    <base href="https://dyalog.github.io/documentation/latest/"></base>
+    <base href="https://docs.dyalog.com/20.0/"></base>
   </head>
   <body>
     <main>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" type="image/png" href="logo.png" />
     <title>Dyalog APL - Vocabulary</title>
-    <base href="https://docs.dyalog.com/20.0/"></base>
+    <base href="https://docs.dyalog.com/20.0/" />
   </head>
   <body>
     <main>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             <tr>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/add"
+                  href="language-reference-guide/primitive-functions/plus"
                   >Plus</a
                 >
               </td>
@@ -52,21 +52,21 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/symbols/minus-sign"
+                  href="language-reference-guide/symbols/minus"
                   >Minus</a
                 >
               </td>
               <td class="function">-</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/negative"
+                  href="language-reference-guide/primitive-functions/negate"
                   >Negate</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/multiply"
+                  href="language-reference-guide/primitive-functions/times"
                   >Times</a
                 >
               </td>
@@ -155,7 +155,7 @@
             <tr>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/circular"
+                  href="language-reference-guide/primitive-functions/circular-functions"
                 >
                   Circular</a
                 >
@@ -163,7 +163,7 @@
               <td class="function">○</td>
               <td>
                 <a
-                  href="language-reference-guide/ primitive-functions/pi-times"
+                  href="language-reference-guide/primitive-functions/pi-times"
                   >Pi Times</a
                 >
               </td>
@@ -214,7 +214,7 @@
             <tr>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/and-lowest-common-multiple"
+                  href="language-reference-guide/primitive-functions/lowest-common-multiple-and"
                   >And/LCM</a
                 >
               </td>
@@ -223,7 +223,7 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/or-greatest-common-divisor"
+                  href="language-reference-guide/primitive-functions/greatest-common-divisor-or"
                   >Or/GCD</a
                 >
               </td>
@@ -257,7 +257,7 @@
             <tr>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/equal"
+                  href="language-reference-guide/primitive-functions/equal-to"
                   >Equal</a
                 >
               </td>
@@ -266,7 +266,7 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/not-equal"
+                  href="language-reference-guide/primitive-functions/not-equal-to"
                   >Not Equal</a
                 >
               </td>
@@ -311,7 +311,7 @@
             <tr>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/less"
+                  href="language-reference-guide/primitive-functions/less-than"
                   >Less </a
                 >
               </td>
@@ -320,7 +320,7 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/less-or-equal"
+                  href="language-reference-guide/primitive-functions/less-than-or-equal-to"
                   >Less Or <br />
                   Equal</a
                 >
@@ -330,7 +330,7 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/symbols/greater-than-or-equal-to-sign"
+                  href="language-reference-guide/symbols/greater-than-or-equal-to"
                 >
                   Greater Or <br />
                   Equal</a
@@ -341,7 +341,7 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/greater"
+                  href="language-reference-guide/primitive-functions/greater-than"
                   >Greater </a
                 >
               </td>
@@ -352,7 +352,7 @@
             <tr>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/index-with-axes"
+                  href="language-reference-guide/primitive-functions/index-function"
                   >Index</a
                 >
               </td>
@@ -433,7 +433,7 @@
               <td class="function">⊃</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/disclose"
+                  href="language-reference-guide/primitive-functions/first"
                   >First</a
                 >
               </td>
@@ -512,7 +512,7 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/excluding"
+                  href="language-reference-guide/primitive-functions/without"
                   >Without</a
                 >
               </td>
@@ -696,7 +696,7 @@
             <tr>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/transpose-dyadic"
+                  href="language-reference-guide/primitive-functions/dyadic-transpose"
                 >
                   Reorder <br />
                   Axes</a
@@ -705,7 +705,7 @@
               <td class="function">⍉</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/transpose-monadic"
+                  href="language-reference-guide/primitive-functions/transpose"
                   >Transpose</a
                 >
               </td>
@@ -766,7 +766,7 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/format-dyadic"
+                  href="language-reference-guide/primitive-functions/format-by-specification"
                 >
                   Specified <br />
                   Format</a
@@ -775,14 +775,14 @@
               <td class="function">⍕</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/format-monadic"
+                  href="language-reference-guide/primitive-functions/format"
                   >Format</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/grade-up-dyadic"
+                  href="language-reference-guide/primitive-functions/dyadic-grade-up"
                 >
                   Collated <br />
                   Grade Up</a
@@ -791,14 +791,14 @@
               <td class="function">⍋</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/grade-up-monadic"
+                  href="language-reference-guide/primitive-functions/grade-up"
                   >Grade Up</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/grade-down-dyadic"
+                  href="language-reference-guide/primitive-functions/dyadic-grade-down"
                 >
                   Collated <br />
                   Grade Down</a
@@ -807,7 +807,7 @@
               <td class="function">⍒</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/grade-down-monadic"
+                  href="language-reference-guide/primitive-functions/grade-down"
                   >Grade Down</a
                 >
               </td>
@@ -821,14 +821,14 @@
             <tr>
               <td>
                 <a
-                  href="language-reference-guide/primitive-operators/each-with-dyadic-operand"
+                  href="language-reference-guide/primitive-operators/each/each-with-dyadic-operand"
                   >Each</a
                 >
               </td>
               <td class="moperator">f¨</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-operators/each-with-monadic-operand"
+                  href="language-reference-guide/primitive-operators/each/each-with-monadic-operand"
                   >Each</a
                 >
               </td>
@@ -882,7 +882,7 @@
             <tr>
               <td>
                 <a
-                  href="language-reference-guide/primitive-operators/reduce-n-wise"
+                  href="language-reference-guide/primitive-operators/reduce/reduce-n-wise"
                 >
                   Reduce<br />
                   N-Wise </a
@@ -898,7 +898,7 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-operators/reduce-first-n-wise"
+                  href="language-reference-guide/primitive-operators/reduce-first/reduce-first-n-wise"
                 >
                   Reduce First<br />
                   N-Wise </a
@@ -968,21 +968,21 @@
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/https://help.dyalog.com/latest/#language/primitive-operators/axis-with-dyadic-operand"
+                  href="language-reference-guide/other-syntax/axis/axis-with-dyadic-operand"
                   >Axis</a
                 >
               </td>
               <td class="moperator">f[X]</td>
               <td>
                 <a
-                  href="language-reference-guide/https://help.dyalog.com/latest/#language/primitive-operators/axis-with-monadic-operand"
+                  href="language-reference-guide/other-syntax/axis/axis-with-monadic-operand"
                   >Axis</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/https://help.dyalog.com/latest/#language/primitive-operators/outer-product"
+                  href="language-reference-guide/primitive-operators/outer-product"
                 >
                   Outer <br />
                   Product</a
@@ -1170,7 +1170,7 @@
               <td></td>
              <td>
                 <a
-                  href="language-reference-guide/primitive-operators/power-operator"
+                  href="language-reference-guide/primitive-operators/power"
                   >Bound<br/>
                   Until</a
                 >
@@ -1178,14 +1178,14 @@
               <td class="doperator">f⍣g</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-operators/power-operator"
+                  href="language-reference-guide/primitive-operators/power"
                   >Until</a
                 >
               </td>
               <td></td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-operators/power-operator"
+                  href="language-reference-guide/primitive-operators/power"
                   >Bound<br/>
                   Repeat</a
                 >
@@ -1193,7 +1193,7 @@
               <td class="doperator">f⍣Y</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-operators/power-operator"
+                  href="language-reference-guide/primitive-operators/power"
                   >Repeat</a
                 >
              <tr
@@ -1206,7 +1206,7 @@
               <td class="control">→</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/abort"
+                  href="language-reference-guide/other-syntax/abort"
                   >Abort</a
                 >
               </td>
@@ -1278,7 +1278,7 @@
               <td class="noun">⍬</td>
               <td>
                 <a
-                  href="language-reference-guide/primitive-functions/zilde"
+                  href="language-reference-guide/other-syntax/zilde"
                 >
                   Empty <br />
                   Numeric Vector</a
@@ -1424,7 +1424,7 @@
               <td class="function" style="font-size: 0.75em;white-space: nowrap;">(X g h)</td>
               <td>
                 <a
-                  href="language-reference-guide/introduction/trains"
+                  href="programming-reference-guide/introduction/trains"
                   >Fork</a
                 >
               </td>


### PR DESCRIPTION
As #3 states, the help urls have changed for v20.0